### PR TITLE
Extend the time a block of subtitles is shown.

### DIFF
--- a/service.subtitles.translate/resources/language/resource.language.en_gb/strings.po
+++ b/service.subtitles.translate/resources/language/resource.language.en_gb/strings.po
@@ -45,6 +45,10 @@ msgctxt "#30106"
 msgid "Filter music between hashtags"
 msgstr ""
 
+msgctxt "#30131"
+msgid "Time to display a block of subtitles"
+msgstr ""
+
 msgctxt "#30190"
 msgid "Logging"
 msgstr ""
@@ -89,9 +93,14 @@ msgid "Some subtitles display music and lyrics between hashtags.\n"
 "If this filter is enabled an attempt is made to remove this."
 msgstr ""
 
+msgctxt "#30331"
+msgid "Number of seconds the subtitles should preferably remain shown on screen.\n"
+"If the next block of subtitles comes up earlier, keep the current block on screen as long as possible."
+msgstr ""
+
 msgctxt "#30391"
 msgid "Select whether the addon logs to 'Kodi log' (default) its own log file stored in the user data directory,\n"
-"or doesn't log at all. A restart of Kodi is required befor new settings take effect."
+"or doesn't log at all. A restart of Kodi is required before new settings take effect."
 msgstr ""
 
 # Script texts

--- a/service.subtitles.translate/resources/lib/subtitles/convert.py
+++ b/service.subtitles.translate/resources/lib/subtitles/convert.py
@@ -95,7 +95,7 @@ def vtt_to_srt(vtt_doc: str, colourize=True) -> str:
     from io import StringIO
     import re
 
-    # Match a line that start with cue timings. Accept timings with or without hours.
+    # Match a line that starts with cue timings. Accept timings with or without hours.
     regex = re.compile(r'(\d{2})?:?(\d{2}:\d{2})\.(\d{3}) +--> +(\d{2})?:?(\d{2}:\d{2})\.(\d{3})')
 
     # Convert new lines conform WebVTT specs
@@ -140,7 +140,7 @@ def vtt_to_srt(vtt_doc: str, colourize=True) -> str:
         # Remove any markup tag other than the supported bold, italic underline and colour.
         srt_doc = re.sub(r'<([^biuc]).*?>(.*?)</\1.*?>', r'\2', srt_doc)
 
-        # convert color tags, accept only simple colour names.
+        # convert color tags.
         def sub_color_tags(match):
             colour = match[1]
             if colour in ('white', 'yellow', 'green', 'cyan', 'red'):

--- a/service.subtitles.translate/resources/lib/subtitles/merge.py
+++ b/service.subtitles.translate/resources/lib/subtitles/merge.py
@@ -25,7 +25,7 @@ class Sentence:
 
     @text.setter
     def text(self, new_text):
-        """Divide new_text over all lines in such a way that each line has a relative
+        """Spread new_text over all lines in such a way that each line has a relative
         length similar to the original. All in an attempt to keep the timing of the
         new subtitles as close to the original as possible.
 

--- a/service.subtitles.translate/resources/lib/subtitles/subtitle.py
+++ b/service.subtitles.translate/resources/lib/subtitles/subtitle.py
@@ -6,7 +6,14 @@
 # ----------------------------------------------------------------------------------------------------------------------
 
 from __future__ import annotations
+
+import logging
 import re
+
+from resources.lib import utils
+
+
+logger = logging.getLogger('.'.join((utils.logger_id, __name__.split('.', 2)[-1])))
 
 # Regex to parse a line with optional multiple tags of various types, like colour, bold, etc.
 # Only font (colour) tags are captured, all other tags are disregarded. I'm not quite sure if and how
@@ -176,8 +183,13 @@ class SrtDoc:
         blocks_iter = iter(self.blocks)
         b1 = next(blocks_iter)
         for b2 in blocks_iter:
-            t_dif = b2.start_time - b1.end_time
-            if t_dif > 0:
-                new_end_t = min(b1.start_time + display_time, b1.end_time + t_dif)
+            if not b2:
+                continue
+            et = b1.end_time
+            st = b2.start_time
+            if st > et:
+                new_end_t = min(b1.start_time + display_time, st)
                 b1.end_time = new_end_t
+                logger.debug("stretched display endTime from %02.0f:%02.0f:%06.3f to %02.0f:%02.0f:%06.3f",
+                             et/3600, (et%3600)/60, et%60, new_end_t/3600, (new_end_t%3600)/60, new_end_t%60)
             b1 = b2

--- a/service.subtitles.translate/resources/lib/subtitles/translate.py
+++ b/service.subtitles.translate/resources/lib/subtitles/translate.py
@@ -153,7 +153,8 @@ def translate_file(video_file: str,
                    file_type: str,
                    target_lang: str = 'auto',
                    src_lang: str = 'auto',
-                   filter_flags: int = -1) -> str | None:
+                   filter_flags: int = -1,
+                   display_time: float = 0) -> str | None:
     """
     Translate an srt file into target_lang and return the path to the translated document.
     Returns an already saved document if it is found in the cache. If not, an online translation
@@ -166,8 +167,9 @@ def translate_file(video_file: str,
     :param target_lang: Language of the translation.
     :param src_lang: Language of the original subtitles. Can be 'auto' tot let the translation
         service auto-detect the langauge.
-    :return: The path to the translated srt document on success, or None on failure.
     :param filter_flags: Bitmask of FILTER_xxxx flags.
+    :param display_time: Preferred number of seconds a subtitle block should remain visible.
+    :return: The path to the translated srt document on success, or None on failure.
 
     """
     # delete previously stored intermediate files
@@ -233,6 +235,8 @@ def translate_file(video_file: str,
             return
 
         merged_obj.text = new_txt
+        if display_time:
+            orig_subs_obj.stretch_time(display_time)
         translated_srt = str(orig_subs_obj)
         with open(cache_file_name, 'w', encoding='utf8') as f:
             f.write(translated_srt)

--- a/service.subtitles.translate/resources/lib/subtitles/translate.py
+++ b/service.subtitles.translate/resources/lib/subtitles/translate.py
@@ -236,6 +236,7 @@ def translate_file(video_file: str,
 
         merged_obj.text = new_txt
         if display_time:
+            logger.debug("Trying to stretch display time to %s sec.", display_time)
             orig_subs_obj.stretch_time(display_time)
         translated_srt = str(orig_subs_obj)
         with open(cache_file_name, 'w', encoding='utf8') as f:

--- a/service.subtitles.translate/resources/settings.xml
+++ b/service.subtitles.translate/resources/settings.xml
@@ -9,6 +9,13 @@
 					<default>true</default>
 					<control type="toggle"/>
 				</setting>
+				<setting id="display_time" label="30131" type="number" help="30331">
+					<level>0</level>
+					<default>0</default>
+					<control type="edit" format="number">
+						<heading>30131</heading>
+					</control>
+				</setting>
 			</group>
 			<group id="grp1" label="30101">
 				<setting id="filter_colour" label="30103" type="boolean" help="30303" >

--- a/service.subtitles.translate/service.py
+++ b/service.subtitles.translate/service.py
@@ -82,8 +82,10 @@ class PlayerMonitor(Player):
         logger.info("Subtitles filter_flags: '%s'", filter_flags)
         logger.info("Video ID: %s", video_file)
 
+        preferred_display_time = utils.addon_info.addon.getSettingNumber('display_time')
         translated_fname = translate.translate_file(video_file, file_name, subs_type,
-                                                    src_lang=orig_lang, filter_flags=filter_flags)
+                                                    src_lang=orig_lang, filter_flags=filter_flags,
+                                                    display_time=preferred_display_time)
         if not translated_fname:
             return
         # Translating can take some time, check if the file is still playing

--- a/service.subtitles.translate/service.py
+++ b/service.subtitles.translate/service.py
@@ -75,14 +75,15 @@ class PlayerMonitor(Player):
 
         # Strip the querystring from the video url, because it may contain items unique to every instance played.
         video_file = self.getPlayingFile().split('?')[0]
+        preferred_display_time = utils.addon_info.addon.getSettingNumber('display_time')
 
         logger.info("Subtitles file: '%s'", file_name)
         logger.info("Subtitles type: '%s'", subs_type)
         logger.info("Subtitles original language: '%s'", orig_lang)
         logger.info("Subtitles filter_flags: '%s'", filter_flags)
         logger.info("Video ID: %s", video_file)
+        logger.info("Display time: %s", preferred_display_time)
 
-        preferred_display_time = utils.addon_info.addon.getSettingNumber('display_time')
         translated_fname = translate.translate_file(video_file, file_name, subs_type,
                                                     src_lang=orig_lang, filter_flags=filter_flags,
                                                     display_time=preferred_display_time)
@@ -105,6 +106,8 @@ if __name__ == '__main__':
             player = PlayerMonitor()
             while system_monitor.abortRequested() is False:
                 system_monitor.waitForAbort(86400)
+                logger.info("Abort requested")
                 translate.cleanup_cached_files()
         except Exception as e:
             logger.error("Unhandled exception: %r:", e, exc_info=True)
+    logger.info("Ended service")

--- a/test/local/test_subtitle.py
+++ b/test/local/test_subtitle.py
@@ -16,7 +16,6 @@ from resources.lib.subtitles import subtitle
 from test.support.testutils import open_doc
 
 
-
 class TestLine(unittest.TestCase):
     def test_text_line(self):
         txt = 'This is text'
@@ -104,3 +103,31 @@ class TestSrtBlock(unittest.TestCase):
         self.assertTrue(block)
         self.assertEqual(2, len(block.lines))
         self.assertEqual(2, len(list(block)))
+
+    def test_parse_time_line(self):
+        b = subtitle.SrtBlock('')
+        b._parse_time_line('00:03:02,961 --> 00:03:02,961')
+        self.assertEqual(3 * 60 + 2.961, b.start_time)
+        self.assertEqual(3 * 60 + 2.961, b.end_time)
+        b._parse_time_line('10:13:20,9 --> 02:03:22,60')
+        self.assertEqual(10 * 3600 + 13 * 60 + 20.9, b.start_time)
+        self.assertEqual(2 * 3600 + 3 * 60 + 22.60, b.end_time)
+
+    def test_format_time_line(self):
+        b = subtitle.SrtBlock('')
+        b.start_time = 10 * 3600 + 11 * 60 + 21.9
+        b.end_time = b.start_time
+        self.assertEqual('10:11:21,900 --> 10:11:21,900', b._format_time_line())
+        b.start_time = 1 * 3600 + 3 * 60 + 2.9623
+        b.end_time = b.start_time
+        self.assertEqual('01:03:02,962 --> 01:03:02,962', b._format_time_line())
+
+
+class TestSrtDoc(unittest.TestCase):
+    def test_create_doc(self):
+        srt = subtitle.SrtDoc(open_doc('srt/spy_among_friends.en.srt')())
+
+    def test_stretch_time(self):
+        srt = subtitle.SrtDoc(open_doc('srt/spy_among_friends.en.srt')())
+        srt.stretch_time(7)
+        print(str(srt))

--- a/test/local/test_subtitle.py
+++ b/test/local/test_subtitle.py
@@ -83,6 +83,11 @@ class TestLine(unittest.TestCase):
         line = subtitle.SrtLine('<font color="cyan"> </font>')
         self.assertEqual(0, len(line._frases))
 
+    def test__bool_(self):
+        self.assertFalse(subtitle.SrtLine(''))
+        self.assertFalse(subtitle.SrtLine('<font color="cyan"> </font>'))
+        self.assertTrue(subtitle.SrtLine(' <font color="cyan"> This is text </font>'))
+
 
 test_block ="""
 1
@@ -121,6 +126,13 @@ class TestSrtBlock(unittest.TestCase):
         b.start_time = 1 * 3600 + 3 * 60 + 2.9623
         b.end_time = b.start_time
         self.assertEqual('01:03:02,962 --> 01:03:02,962', b._format_time_line())
+
+    def test__bool_(self):
+        self.assertFalse(subtitle.SrtBlock(test_block))
+        self.assertFalse(subtitle.SrtBlock(test_block + ''))
+        self.assertFalse(subtitle.SrtBlock(test_block + ' \n '))
+        self.assertTrue(subtitle.SrtBlock(test_block + 'this is the first line'))
+        self.assertTrue(subtitle.SrtBlock(test_block + '\nthis is the second line'))
 
 
 class TestSrtDoc(unittest.TestCase):


### PR DESCRIPTION
Sometimes a block of subtitles is shown for such a short period that they can barely be read all the way through.

This PR adds a setting to the addon that enable users to define the amount of seconds a block of subtitles should remains displayed on screen. Translate subs will extend the display time of a block as much as possible up to the preferred display time, without overlapping the next block. 

Display time stretching only extends time whenever possible. It will never shorten the time a block remains on screen and will never shift the start time of block.